### PR TITLE
Add option to sort albums by artists

### DIFF
--- a/src/js/views/library/LibraryAlbums.js
+++ b/src/js/views/library/LibraryAlbums.js
@@ -162,6 +162,10 @@ class LibraryAlbums extends React.Component{
 
 		var sort_options = [
 			{
+				value: 'artists',
+				label: 'Artists'
+			},
+			{
 				value: 'name',
 				label: 'Name'
 			},


### PR DESCRIPTION
When album list is sorted by some attribute it is not possible to restore default sort order (by artist). This pull requests adds ability to sort by artists.