### PR TITLE
Add iOS homescreen icon

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,7 @@
 	<link rel="shortcut icon" type="image/ico" href="/iris/assets/favicon.ico" />
 	<link rel="shortcut icon" type="image/x-icon" href="/iris/assets/favicon.ico" />
 	<link rel="shortcut-icon" href="/iris/assets/favicon.ico" />
+	<link rel="apple-touch-icon-precomposed" sizes="512x512" href="/iris/assets/icon-512.png" />
 
 	<link href="//fonts.googleapis.com/css?family=Overpass:400,400i,600,700,800" rel="stylesheet">
 	<link href="/iris/app.css" rel="stylesheet" />


### PR DESCRIPTION
This pull request adds a `apple-touch-icon-precomposed` \<link/\> tag which is used by iOS devices when a user adds a website to their homescreen.

---

This is what the icon looks like on iOS:

![This is what the homescreen icon looks like on an iPhone 6s](https://user-images.githubusercontent.com/101739/30040240-706302d0-91d4-11e7-89a2-45556b530e5a.jpg)
