### PR TITLE
Change .length to .get_length()

### DIFF
--- a/mopidy_iris/core.py
+++ b/mopidy_iris/core.py
@@ -748,7 +748,7 @@ class IrisCore(pykka.ThreadingActor):
 
 
     def check_for_radio_update( self ):
-        tracklistLength = self.core.tracklist.length.get()
+        tracklistLength = self.core.tracklist.get_length().get()
         if (tracklistLength < 3 and self.radio['enabled'] == 1):
 
             # Grab our loaded tracks


### PR DESCRIPTION
Looks like there was a breaking API change at some point (https://docs.mopidy.com/en/latest/api/core/#mopidy.core.TracklistController.get_length); this line was giving me exceptions.