### PR TITLE
adds sudo package to the Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
        python-tornado \
        git \
        nano \
+       sudo \
  && curl -L https://apt.mopidy.com/mopidy.gpg | apt-key add - \
  && curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list \
  && apt-get update \


### PR DESCRIPTION
Everything seems to work well using your Dockerfile, except from trying to upgrade Iris using the UI. That's because `sudo` isn't installed it seems.