### PR TITLE
Fix checking the boolean flag

### DIFF
--- a/mopidy_iris/system.sh
+++ b/mopidy_iris/system.sh
@@ -7,7 +7,7 @@ else
 fi
 
 if [[ $1 = "upgrade" ]]; then
-	if [[ $IS_CONTAINER ]]; then
+	if $IS_CONTAINER; then
 		echo "cd /iris && git checkout master && git pull origin master"
 		UPGRADE="$(cd /iris && git checkout master && git pull origin master)"
 	else
@@ -17,7 +17,7 @@ if [[ $1 = "upgrade" ]]; then
 	echo -e "${UPGRADE}"
 
 elif [[ $1 = "restart" ]]; then
-	if [[ $IS_CONTAINER ]]; then
+	if $IS_CONTAINER; then
 		echo -e "Cannot restart Mopidy when running in a Docker container"
 		exit 1
 	else
@@ -26,8 +26,7 @@ elif [[ $1 = "restart" ]]; then
 	fi
 
 elif [[ $1 = "local_scan" ]]; then
-
-	if [[ $IS_CONTAINER ]]; then
+	if $IS_CONTAINER; then
 		SCAN="$(mopidy --config /config/mopidy.conf local scan)"
 	else
 		SCAN="$(sudo mopidyctl local scan)"
@@ -38,7 +37,6 @@ elif [[ $1 = "check" ]]; then
 	echo -e "Access permitted"
 
 elif [[ $1 = "test" ]]; then
-
 	sleep 3
 
 	TEST=$(echo "Hello, this is your bash speaking. I was sleeping for 3 seconds. Is running a container: $IS_CONTAINER")


### PR DESCRIPTION
``[[ $flag ]]`` checks if the variable is not empty. Not if it's true or false. Which means it will always succeed, because both possible values (``true`` and ``false``) are not empty.

An alternative would be ``[[ "$flag" = "true" ]]``.

Fixes some points mentioned in #489. Doesn't address changing `pip` to `pip3` (or maybe even ``python3 -m pip``) or the missing detection of the version number.