### PR TITLE
Feature/playlist track order

### DIFF
--- a/src/js/services/core/actions.js
+++ b/src/js/services/core/actions.js
@@ -139,11 +139,12 @@ export function loadArtist(uri, force_reload = false) {
   };
 }
 
-export function loadPlaylist(uri, force_reload = false) {
+export function loadPlaylist(uri, force_reload = false, filters = {}) {
   return {
     type: 'LOAD_PLAYLIST',
     uri,
     force_reload,
+    filters,
   };
 }
 

--- a/src/js/services/core/middleware.js
+++ b/src/js/services/core/middleware.js
@@ -759,6 +759,14 @@ const CoreMiddleware = (function () {
           records = formatTracks(records);
         }
 
+        var records_next = action.records_data.next;
+
+        // Handle ordering
+        if (parent.order === 'INVERTED') {
+          records = records.reverse();
+          records_next = action.records_data.previous;
+        }
+
         var records_type_plural = `${action.records_type}s`;
         var records_index = {};
         var records_uris = arrayOf('uri', records);
@@ -780,8 +788,8 @@ const CoreMiddleware = (function () {
           uris = [...parent[`${records_type_plural}_uris`], ...uris];
         }
         parent[`${records_type_plural}_uris`] = uris;
-        if (action.records_data.next !== undefined) {
-          parent[`${records_type_plural}_more`] = action.records_data.next;
+        if (records_next !== undefined) {
+          parent[`${records_type_plural}_more`] = records_next;
         }
 
         // Parent loaded (well, changed)

--- a/src/js/services/core/middleware.js
+++ b/src/js/services/core/middleware.js
@@ -416,9 +416,11 @@ const CoreMiddleware = (function () {
           break;
         }
 
+        const { sort } = action.filters || {}
+
         switch (uriSource(action.uri)) {
           case 'spotify':
-            store.dispatch(spotifyActions.getPlaylist(action.uri));
+            store.dispatch(spotifyActions.getPlaylist(action.uri, sort));
 
             if (store.getState().spotify.me) {
               store.dispatch(spotifyActions.following(action.uri));
@@ -762,7 +764,7 @@ const CoreMiddleware = (function () {
         var records_next = action.records_data.next;
 
         // Handle ordering
-        if (parent.order === 'INVERTED') {
+        if (parent.order === 'reverse') {
           records = records.reverse();
           records_next = action.records_data.previous;
         }

--- a/src/js/services/spotify/actions.js
+++ b/src/js/services/spotify/actions.js
@@ -1493,7 +1493,7 @@ export function savePlaylist(uri, name, description, is_public, is_collaborative
   };
 }
 
-export function getPlaylist(uri) {
+export function getPlaylist(uri, order=null) {
   const fields = 'collaborative,description,followers(total),images,name,owner(display_name,id,images,uri),public,tracks(total),uri';
   return (dispatch, getState) => {
     // get the main playlist object
@@ -1511,11 +1511,10 @@ export function getPlaylist(uri) {
 
           const tracks = formatTracks(response.tracks.items);
 
-          let order = 'INVERTED';
           let limit = 100;
           let tracks_more = `playlists/${getFromUri('playlistid', uri)}/tracks?limit=${limit}&market=${getState().spotify.country}`;
 
-          if (order === 'INVERTED') {
+          if (order === 'reverse') {
             // Invert tracks paging starting from end
             tracks_more += `&offset=${Math.max(response.tracks.total - 100, 0)}`;
           }

--- a/src/js/util/format.js
+++ b/src/js/util/format.js
@@ -407,6 +407,7 @@ const formatPlaylist = function (data) {
     'last_modified',
     'can_edit',
     'owner',
+    'order',
     'user_uri',
     'tracks_uris',
     'tracks_total',

--- a/src/js/views/Playlist.js
+++ b/src/js/views/Playlist.js
@@ -83,8 +83,6 @@ class Playlist extends React.Component {
       },
     } = this.props;
 
-    console.log("updated", this.props)
-
     if (prevPlaylist && playlist && prevPlaylist.moved_to !== playlist.moved_to) {
       push(`/playlist/${encodeURIComponent(playlist.moved_to)}`);
     }
@@ -189,7 +187,7 @@ class Playlist extends React.Component {
         selected_icon={this.props.sort ? (this.props.sort_reverse ? 'keyboard_arrow_up' : 'keyboard_arrow_down') : null}
         handleChange={(value) => { this.setSort(value); this.props.uiActions.hideContextMenu(); }}
       />
-    )
+    );
   }
 
   renderActions() {

--- a/src/js/views/Playlist.js
+++ b/src/js/views/Playlist.js
@@ -56,8 +56,11 @@ class Playlist extends React.Component {
   }
 
   componentDidMount() {
-    const { coreActions: { loadPlaylist }, uri } = this.props;
+    const { coreActions: { loadPlaylist }, uri, order } = this.props;
     this.setWindowTitle();
+    if (order === undefined) {
+      this.setSort('reverse');
+    }
     loadPlaylist(uri, false, { sort: this.props.sort });
   }
 


### PR DESCRIPTION
This PR tries to implement feature request #568.

Allows loading tracks of Spotify playlists in revered order, leading the newest track to be first in a list. Instead of paging tracks from start to end, with this feature, we can page tracks from end to start.

This PR contains:  
- Changes how Spotify APIs (playlist and tracks) is and can be called, and respective changes in actions and middleware.
- UI updates on the Playlist view to be able to choose between default and reverse sorting.

Hopefully, this PR serves as a good starting point to implement this feature in master branch.