### PR TITLE
Fix bug with refreshing playlists where only the first page would be refreshed

### DIFF
--- a/src/js/services/spotify/actions.js
+++ b/src/js/services/spotify/actions.js
@@ -940,7 +940,7 @@ export function getArtist(uri, { full, forceRefetch } = {}) {
         .then((response) => {
           albums = [...albums, ...formatAlbums(response.items)];
           if (response.next) {
-            fetchAlbums(response.next);
+            fetchAlbums(`${response.next}${forceRefetch ? `&refetch=${Date.now()}` : ''}`);
           } else {
             dispatch(coreActions.itemLoaded({
               uri,
@@ -1057,7 +1057,7 @@ export function getUser(uri, { full, forceRefetch } = {}) {
         .then((response) => {
           playlists = [...playlists, ...formatPlaylists(response.items)];
           if (response.next) {
-            fetchPlaylists(response.next);
+            fetchPlaylists(`${response.next}${forceRefetch ? `&refetch=${Date.now()}` : ''}`);
           } else {
             dispatch(coreActions.itemLoaded({
               uri,
@@ -1110,7 +1110,7 @@ export function getAlbum(uri, { full, forceRefetch } = {}) {
             (response) => {
               tracks = [...tracks, ...formatTracks(response.items)];
               if (response.next) {
-                fetchTracks(response.next);
+                fetchTracks(`${response.next}${forceRefetch ? `&refetch=${Date.now()}` : ''}`);
               } else {
                 dispatch(coreActions.itemLoaded({
                   uri,
@@ -1284,7 +1284,7 @@ export function getPlaylistTracks(uri, { forceRefetch, callbackAction } = {}) {
       .then((response) => {
         tracks = [...tracks, ...formatTracks(response.items)];
         if (response.next) {
-          fetchTracks(response.next);
+          fetchTracks(`${response.next}${forceRefetch ? `&refetch=${Date.now()}` : ''}`);
         } else {
           dispatch(coreActions.itemLoaded({
             uri,


### PR DESCRIPTION
When `getPlaylistTracks` was called with with `forceRefetch = true`  (by clicking the refresh button in the playlist view), only the first page would get the refresh query parameter appended.

This patch appends the refresh query parameter to all subsequent requests as well