### PR TITLE
Fix error refreshing tracks caused by uri.replace on null

### DIFF
--- a/src/js/util/format.js
+++ b/src/js/util/format.js
@@ -698,7 +698,9 @@ const formatTrack = function (data) {
 
   // Remove lower-case encoding of ':'
   // See https://github.com/tkem/mopidy-dleyna/issues/72
-  track.uri = track.uri.replace('%3a', '%3A');
+  if (track.uri) {
+    track.uri = track.uri.replace('%3a', '%3A');
+  }
 
   return track;
 };


### PR DESCRIPTION
In some cases a track entry from spotify may contain "track": null. See this example response from spotify: https://gist.github.com/ineentho/97ef4f2695cc816decd1ff216466e81b#file-response-json-L1509

formatTrack assumed that track always was a string, causing an error that prevented the playlist from refreshing.

I'm not sure what caused the playlist to contain a null entry, but the desktop client only shows 29 out of the 30 songs in the release radar, so I assume one track was removed for some reason.