### PR TITLE
Update docker/entrypoint.sh to allow for sideloading of PIP packages (e.g. additional mopidy plugins)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,4 +6,9 @@ then
     export PULSE_COOKIE=$HOME/pulse.cookie
 fi
 
+if [ ${PIP_PACKAGES:+x} ]; then
+	echo "-- INSTALLING PIP PACKAGES $PIP_PACKAGES --"
+	python3 -m pip install --no-cache $PIP_PACKAGES
+fi
+
 exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,8 +7,8 @@ then
 fi
 
 if [ ${PIP_PACKAGES:+x} ]; then
-	echo "-- INSTALLING PIP PACKAGES $PIP_PACKAGES --"
-	python3 -m pip install --no-cache $PIP_PACKAGES
+    echo "-- INSTALLING PIP PACKAGES $PIP_PACKAGES --"
+    python3 -m pip install --no-cache $PIP_PACKAGES
 fi
 
 exec "$@"


### PR DESCRIPTION
On the Wiki, I would also add a sixth list item under ¨Getting-started > To install using Docker¨ to explain the new functionality:

6. If you want to sideload additional PIP packages to your Docker container, these can be specified using the `PIP_PACKAGES` environment variable, demarcated by a space between different packages