### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Install libspotify-dev from apt.mopidy.com
-RUN wget -q -O - https://apt.mopidy.com/mopidy.gpg \
-  | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add - \
+RUN mkdir -p /usr/local/share/keyrings \
+  && wget -q -O /usr/local/share/keyrings/mopidy-archive-keyring.gpg https://apt.mopidy.com/mopidy.gpg \
   && wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/buster.list \
   && apt-get update \
   && apt-get install -y libspotify-dev mopidy-spotify \


### PR DESCRIPTION
Updated to latest mopidy APT repo installation routine (see https://docs.mopidy.com/en/latest/installation/debian/) to fix GPG error.