### PR TITLE
feat(docker): also update the specified pip packages rather than just installing them

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 if [ ${PIP_PACKAGES:+x} ]; then
     echo "-- INSTALLING PIP PACKAGES $PIP_PACKAGES --"
-    python3 -m pip install --no-cache $PIP_PACKAGES
+    python3 -m pip install --no-cache --upgrade $PIP_PACKAGES
 fi
 
 exec "$@"


### PR DESCRIPTION
Some pip packages may get updates and subsequent container runs wouldn't install them. Not so much of a problem normally but when for example yt-dlp is installed through pip to use with mopidy-youtube it's important to keep yt-dlp up-to-date to not have functionality be broken when Youtube updates their webpage again