### PR TITLE
Fix typo in system.sh script

### DIFF
--- a/mopidy_iris/system.sh
+++ b/mopidy_iris/system.sh
@@ -32,6 +32,7 @@ elif [[ $1 = "local_scan" ]]; then
 			SCAN=$(mopidy --config $IRIS_CONFIG_LOCATION local scan)
 		else
 			SCAN=$(mopidy --config /config/mopidy.conf local scan)
+		fi
 	else
 		SCAN=$(sudo mopidyctl local scan)
 	fi


### PR DESCRIPTION
Adds an `fi` to an if statement block - was causing issues with running commands in `system.sh` (e.g. `local_scan`), both via web UI and terminal.