### PR TITLE
fix(docker): replace youtube_dl for yt-dlp

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -5,5 +5,5 @@ Mopidy-Soundcloud
 Mopidy-Youtube
 Mopidy-YTMusic
 ytmusicapi
-youtube_dl
+yt-dlp
 tox


### PR DESCRIPTION
youtube_dl has been on low maintenance for quite a while and is actually broken for Youtube currently. yt-dlp is the actively maintained fork and should be used instead.

Closes #924