### PR TITLE
Sort nested directories as a separate section

### DIFF
--- a/src/js/views/Library/BrowseDirectory.js
+++ b/src/js/views/Library/BrowseDirectory.js
@@ -143,6 +143,8 @@ const BrowseDirectory = () => {
     subdirectories = applyFilter('name', filter, subdirectories);
     tracks = applyFilter('name', filter, tracks);
   }
+  let items = subdirectories.filter((item) => item.type != 'directory');
+  subdirectories = subdirectories.filter((item) => item.type == 'directory');
 
   const view_options = [
     {
@@ -205,6 +207,7 @@ const BrowseDirectory = () => {
         <ErrorBoundary>
 
           <Subdirectories items={subdirectories} view={view} />
+          <Subdirectories items={items} view={view} />
 
           <TrackList
             context={{


### PR DESCRIPTION
Mopidy-Bandcamp uses a nested More directory for pagination and so this will bring such directories to the top of the list of albums