### PR TITLE
Add Subidy and WebM3U support

### DIFF
--- a/src/js/util/helpers.js
+++ b/src/js/util/helpers.js
@@ -140,8 +140,10 @@ const uriType = function (uri) {
   if (!uri) return '';
 
   const exploded = `${uri}`.split(':');
+  const is_playlist_uri = exploded.length >= 1 && exploded[1] === 'playlist'
 
-  if (exploded[0] === 'm3u') {
+  // The following covers m3u, webm3u, subidy:playlist URI schemes.
+  if (exploded[0].endsWith('m3u') || is_playlist_uri) {
     return 'playlist';
   }
 
@@ -193,8 +195,10 @@ const sourceIcon = function (uri, source = null) {
   if (uri) source = uriSource(uri);
   switch (source) {
     case 'local':
-    case 'm3u':
     case 'file':
+    case 'm3u':
+    case 'webm3u':
+    case 'subidy':
       return 'folder';
 
     case 'gmusic':

--- a/src/js/util/selectors.js
+++ b/src/js/util/selectors.js
@@ -108,6 +108,16 @@ const providers = {
       title: i18n('services.mopidy.local'),
     },
     {
+      scheme: 'webm3u:',
+      uri: 'webm3u:playlists',
+      title: i18n('services.webm3u.title'),
+    },
+    {
+      scheme: 'subidy:',
+      uri: 'subidy:playlists',
+      title: i18n('services.subidy.title'),
+    },
+    {
       scheme: 'spotify:',
       uri: 'spotify:library:playlists',
       title: i18n('services.spotify.title'),
@@ -133,6 +143,11 @@ const providers = {
       scheme: 'local:',
       setting_name: 'library_albums_uri',
       title: i18n('services.mopidy.local'),
+    },
+    {
+      scheme: 'subidy:',
+      uri: 'subidy:vdir:albums',
+      title: i18n('services.subidy.title'),
     },
     {
       scheme: 'gmusic:',
@@ -165,6 +180,11 @@ const providers = {
       scheme: 'local:',
       setting_name: 'library_artists_uri',
       title: i18n('services.mopidy.local'),
+    },
+    {
+      scheme: 'subidy:',
+      uri: 'subidy:vdir:artists',
+      title: i18n('services.subidy.title'),
     },
     {
       scheme: 'gmusic:',


### PR DESCRIPTION
* Display the playlists provided by the [Mopidy-Subidy](https://github.com/Prior99/mopidy-subidy) and [Mopidy-WebM3U](https://github.com/mgoltzsche/mopidy-webm3u) extensions in addition to the ones provided by the built-in M3U plugin.
* Show artists and albums from the [Mopidy-Subidy](https://github.com/Prior99/mopidy-subidy) backend (served by a Subsonic server).