### PR TITLE
fix(docker): correct git clone command for retrieving mopidy-spotify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,8 +130,7 @@ RUN git clone --depth 1 --single-branch -b ${IRIS_VERSION} https://github.com/ja
 
 # Install Mopidy Spotify
 ARG MOPIDY_SPOTIFY_TAG=v5.0.0a1
-RUN git clone --depth 1 --single-branch -b ${MOPIDY_SPOTIFY_TAG} \
- && https://github.com/mopidy/mopidy-spotify.git mopidy-spotify \
+RUN git clone --depth 1 --single-branch -b ${MOPIDY_SPOTIFY_TAG} https://github.com/mopidy/mopidy-spotify.git mopidy-spotify \
  && cd mopidy-spotify \
  && python3 setup.py install \
  && cd .. \


### PR DESCRIPTION
Should fix the pipeline failing to build the Docker image.