### PR TITLE
chore(docker): add alsa-utils to the Alpine Dockerimage

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,6 +13,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
   shadow \
   sudo \
   git \
+  alsa-utils \
   py3-pip \
   mopidy \
   py3-mopidy-spotify


### PR DESCRIPTION
This way the user can use tools like aplay to figure out sound issues from within the container