### PR TITLE
Added missing doctype preamble.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
 	<head>
 		<title>Iris</title>


### PR DESCRIPTION
Context:
> In [HTML](https://developer.mozilla.org/en-US/docs/Glossary/HTML), the doctype is the required <!doctype html> preamble found at the top of all documents.
>
> --<https://developer.mozilla.org/en-US/docs/Glossary/Doctype>