### PR TITLE
Add 'as loaded' sort ordering

### DIFF
--- a/src/js/components/SearchResults.js
+++ b/src/js/components/SearchResults.js
@@ -27,11 +27,13 @@ const SearchResults = ({
   const encodedTerm = encodeURIComponent(term);
   let results = [...rawResults];
 
-  results = sortItems(
-    results,
-    (type === 'tracks' && sortField === 'followers' ? 'popularity' : sortField),
-    sortReverse,
-  );
+  if (sortField) {
+    results = sortItems(
+      results,
+      (type === 'tracks' && sortField === 'followers' ? 'popularity' : sortField),
+      sortReverse,
+    );
+  }
 
   const resultsCount = results.length;
   if (all && type !== 'tracks' && results.length > 5) {

--- a/src/js/views/Search.js
+++ b/src/js/views/Search.js
@@ -70,6 +70,7 @@ const Search = () => {
   }
 
   const sortOptions = [
+    { value: null, label: i18n('fields.filters.as_loaded') },
     { value: 'name', label: i18n('common.name') },
     { value: 'uri', label: i18n('fields.filters.source') },
     { value: 'followers', label: i18n('common.popularity') },


### PR DESCRIPTION
Implemented 'as loaded' search by quite simply not sorting the results.

Resolves #933

I have only tested this with a single source of Spotify, so might be an good idea to test with multiple different sources to make sure it works before merging.