### PR TITLE
fix(docker): don't use a seemingly non-existing variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,6 @@ jobs:
         with:
           push: true
           platforms: linux/amd64,linux/arm64
-          file: "{{context}}/Dockerfile.alpine"
+          file: "Dockerfile.alpine"
           tags: ${{ steps.release_meta.outputs.tags || steps.edge_meta.outputs.tags }}
           labels: ${{ steps.release_meta.outputs.labels || steps.edge_meta.outputs.tags }}


### PR DESCRIPTION
It seems context never actually resolves to anything. Since the Dockerfile is in the root of the repo anyway it should just work to remove the context.

Again, no way to test this for me...