### PR TITLE
fix: ensure IRIS_USE_SUDO is treated as a boolean

### DIFF
--- a/mopidy_iris/system.py
+++ b/mopidy_iris/system.py
@@ -25,7 +25,7 @@ class IrisSystemPermissionError(IrisSystemError):
 
 
 class IrisSystemThread(Thread):
-    _USE_SUDO = os.environ.get("IRIS_USE_SUDO", True)
+    _USE_SUDO = str(os.environ.get("IRIS_USE_SUDO", True)).lower() == "true"
 
     def __init__(self, action, ioloop, callback):
         Thread.__init__(self)


### PR DESCRIPTION
Hi, I was trying to set up Mopidy+Iris in a Docker container using Alpine. I didn't install the sudo package because it seemed unnecessary. However, I found that the local search button didn't work. After investigating, I discovered an issue with how IRIS_USE_SUDO was treated, and I fixed it in this commit.