### PR TITLE
Increase tracklist.add batchSize

### DIFF
--- a/src/js/services/mopidy/middleware.js
+++ b/src/js/services/mopidy/middleware.js
@@ -1036,7 +1036,7 @@ const MopidyMiddleware = (function () {
         // (which is a blocking request), but not so many that it locks the Mopidy server.
         // It allows a window of opportunity for other requests to complete before we proceed to
         // the next batch.
-        const batchSize = 5;
+        const batchSize = 1000;
         const batches = chunk(action.uris, batchSize);
 
         // This is our process iterator


### PR DESCRIPTION
I have a playlist with over 8,000 local tracks in it. Iris took just over 2 hours to add this playlist to the queue.
I have over playlists of 500 tracks which only took a few seconds.

Seems the reason it's taking so long is because Iris is pushing only 5 tracks at a time. I understand there's efficiency reasons for this, but `mpc clear ; mpc load ... ; mpc play` took only <3 seconds with the same 8,000+ track playlist. 
I've done some testing with an effectively infinite batchSize and had no problems at all, and was considering adding an extra zero to the batchSize in this commit to bump it up to 10,000, but figured there might be a real reason for this batching that should be discussed before going that far.

I'm not sure what specific symptoms I can test for "locks the Mopidy server", but this 1,000 batchSize let me add this 8,000 track playlist in ~30s.
Increasing it to 9,000 let me add this playlist in ~5s