### PR TITLE
Fix 'as loaded' sorting in search view

### DIFF
--- a/src/js/components/Fields/DropdownField.js
+++ b/src/js/components/Fields/DropdownField.js
@@ -91,7 +91,7 @@ export default class DropdownField extends React.Component {
 
     if (optionsProp) {
       // Value not set, default to first option
-      if (value === null || value === undefined) {
+      if (value === undefined) {
         selectedOptions = [optionsProp[0]];
       } else if (this.isMultiSelect()) {
         for (const multiSelectValue of value) {

--- a/src/js/util/selectors.js
+++ b/src/js/util/selectors.js
@@ -283,7 +283,7 @@ const makeProvidersSelector = (context) => createSelector(
 const makeSortSelector = (key, defaultField = 'sort_id') => createSelector(
   [getSorts],
   (sorts) => [
-    sorts[key]?.field || defaultField,
+    result?.field === undefined ? defaultField : result.field,
     sorts[key]?.reverse || false,
   ],
 );
@@ -291,7 +291,7 @@ const makeSortSelector = (key, defaultField = 'sort_id') => createSelector(
 const getSortSelector = (state, key, defaultField = 'sort_id') => {
   const result = state.ui.sort[key];
   return [
-    result?.field || defaultField,
+    result?.field === undefined ? defaultField : result.field,
     result?.reverse || false,
   ];
 };


### PR DESCRIPTION
Due to the sort selector returning the default field when value is null it is impossible to select 'as loaded' sorting in the search view, something which was missed after my edit in #976 :sweat_smile: 

After some time debugging i figured out the reason and have created this fix. Although i haven't done much extensive testing from a quick look it does not seem to cause any unintended side-effects.  