### PR TITLE
fix missing album and artist images in search results view

### DIFF
--- a/src/js/components/GridItem.js
+++ b/src/js/components/GridItem.js
@@ -12,6 +12,7 @@ import { isTouchDevice } from '../util/helpers';
 import * as uiActions from '../services/ui/actions';
 import * as mopidyActions from '../services/mopidy/actions';
 import * as spotifyActions from '../services/spotify/actions';
+import * as discogsActions from '../services/discogs/actions';
 
 const SecondaryLine = ({
   sourceIcon = true,
@@ -99,6 +100,8 @@ const GridItem = ({
         case 'artist':
           if (spotify_available) {
             dispatch(spotifyActions.getArtistImages(item));
+          } else {
+            dispatch(discogsActions.getArtistImages(item.uri, item));
           }
           break;
         case 'playlist':

--- a/src/js/components/ListItem.js
+++ b/src/js/components/ListItem.js
@@ -17,6 +17,7 @@ import { updateScrollPosition } from './Link';
 import * as uiActions from '../services/ui/actions';
 import * as mopidyActions from '../services/mopidy/actions';
 import * as spotifyActions from '../services/spotify/actions';
+import * as discogsActions from '../services/discogs/actions';
 import { isTouchDevice } from '../util/helpers';
 
 const getValue = (item = {}, name = '') => {
@@ -112,6 +113,8 @@ const ListItem = ({
         case 'artist':
           if (spotify_available) {
             dispatch(spotifyActions.getArtistImages(item));
+          } else {
+            dispatch(discogsActions.getArtistImages(item.uri, item));
           }
           break;
         case 'album':

--- a/src/js/util/selectors.js
+++ b/src/js/util/selectors.js
@@ -68,13 +68,18 @@ const makeLibrarySelector = (name, filtered = true) => createSelector(
   },
 );
 
-const makeSearchResultsSelector = (providers, term, type) => createSelector(
-  [getSearchResults],
-  (searchResults) => providers.reduce(
-    (acc, curr) => [
-      ...acc,
-      ...searchResults[getSearchResultKey({ provider: curr, term, type })] || [],
-    ], []),
+const makeSearchResultsSelector = (providers, term, type) =>
+  createSelector(
+    [getSearchResults, getItems],
+    (searchResults, items) =>
+      providers.reduce((acc, provider) => {
+        const resultsForProvider = searchResults[getSearchResultKey({ provider, term, type })] || [];
+        const enrichedResults = resultsForProvider.map(result => ({
+          ...result,
+          ...(items[result.uri] || {}), // merge item details if loaded, so we get images in the search result window
+        }));
+        return [...acc, ...enrichedResults];
+      }, [])
   );
 
 const makeProcessProgressSelector = (keys) => createSelector(


### PR DESCRIPTION
This is a pull request to fix an issue with the search result view, where album and artist images were missing in my case.

- album images are missing, because (atleast in my case) the search result items do not include image paths. However the application is already requesting for each album an image, but they then get "reduced" into store.core.images not into the search results. The search result view however is using the the data from store.core.search_results
- artist images were missing in search list view too (alteast in my case), because I don't use spotify. But since it worked for the artist view I looked it up and saw there is a way to load them via discogs. This was used somewhere else alongside with spotify. I added therefore the missing line of code to GridItem and ListItem.