### PR TITLE
Setuptools' pkg_resources deprecation: use packaging instead

### DIFF
--- a/mopidy_iris/core.py
+++ b/mopidy_iris/core.py
@@ -9,8 +9,8 @@ import sys
 import tornado.web
 import tornado.ioloop
 import time
+import packaging
 import pickle
-from pkg_resources import parse_version
 from tornado.escape import json_encode
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
@@ -437,9 +437,9 @@ class IrisCore(pykka.ThreadingActor):
             current_version = Extension.version
 
             # compare our versions, and convert result to boolean
-            upgrade_available = parse_version(latest_version) > parse_version(
-                current_version
-            )
+            upgrade_available = packaging.version.parse(
+                latest_version
+            ) > packaging.version.parse(current_version)
             upgrade_available = upgrade_available == 1
 
         except (urllib.request.HTTPError, urllib.request.URLError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 30.3.0", "wheel"]
+requires = ["setuptools >= 30.3.0", "wheel", "packaging"]
 
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     Mopidy >= 3.0
     Pykka >= 2.0.1
     setuptools
+    packaging
 
 
 [options.extras_require]


### PR DESCRIPTION
Since setuptools v82, the `pkg_resources` module [has been dropped](https://github.com/pypa/setuptools/pull/5007). This PR uses the recommended alternative [`packaging`](https://github.com/pypa/packaging) instead.